### PR TITLE
use exec form of CMD so that signals are handled, and automatic clust…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ENV LIBPROCESS_IP 0.0.0.0
 ENV HOST 0.0.0.0
 ENV PORT_2551 2551
 
-CMD ./mesos-actor-*/bin/mesos-actor
+#create symlink so that we have a well known script name (no wildcards) to execute
+RUN ln -s ./mesos-actor-* ./mesos-actor
+#use the exec form of CMD so that signals will pass to the application script
+CMD ["./mesos-actor/bin/mesos-actor"]
 
 EXPOSE 8080


### PR DESCRIPTION
…er leaving works properly

This avoids the whole area of "when node becomes unreachable, it should be explicitly downed".  Instead, once akka properly receives a SIGTERM, it will:
* start the coordinated shutdown (akka's process for coordinating actors that have special workflows for shutdown)
* if it is participating in a cluster, issue a Cluster.leave()
* wait for the node to be removed from the cluster 
* then finally stop the actor system and system.exit

This allows for a) distinction between transient network issue (should not cause a member to down/leave the cluster) and b) graceful shutdown/restart (should cause a member to leave the cluster without errors)