### PR TITLE
make agentstats TTL configurable; use pureconfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
     compile "com.lightbend.akka:akka-stream-alpakka-simple-codecs_${scalaVersion}:0.9"
     //for JSON printing of protobuf
     compile "com.google.protobuf:protobuf-java-util:3.3.1"
+    //pureconfig for...config
+    compile("com.github.pureconfig:pureconfig_2.12:0.9.0") {
+        exclude group: "org.scala-lang", module: "scala-compiler"
+        exclude group: "org.scala-lang", module: "scala-reflect"
+    }
 
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'
     testCompile "com.typesafe.akka:akka-testkit_${scalaVersion}:${akkaVersion}"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,5 @@
 
 mesos-actor {
-  agent-stats-ttl = 1 minutes //time that agent stats remain valid without an update; incrase time in case offer cycle is slow; decrease time ignore offer data that may be stale
+  agent-stats-ttl = 1 minutes //minimum time that agent stats remain valid without an update; incrase time in case offer cycle is slow; decrease time ignore offer data that may be stale
+  agent-stats-pruning-period = 5 seconds //time period between pruning of expired agent stats
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,4 @@
+
 mesos-actor {
-  agent-stats-ttl = 3 minutes //time that agent stats remain valid without an update; incrase time in case offer cycle is slow; decrease time ignore offer data that may be stale
+  agent-stats-ttl = 1 minutes //time that agent stats remain valid without an update; incrase time in case offer cycle is slow; decrease time ignore offer data that may be stale
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+mesos-actor {
+  agent-stats-ttl = 3 minutes //time that agent stats remain valid without an update; incrase time in case offer cycle is slow; decrease time ignore offer data that may be stale
+}

--- a/src/test/resources/offer1.json
+++ b/src/test/resources/offer1.json
@@ -97,6 +97,9 @@
         "range": [{
           "begin": "11001",
           "end": "11199"
+        },{
+          "begin": "11200",
+          "end": "11202"
         }]
       },
       "role": "*",
@@ -114,6 +117,26 @@
         "role": "*"
       }
     }, {
+      "name": "cpus",
+      "type": "SCALAR",
+      "scalar": {
+        "value": 0.1
+      },
+      "role": "other",
+      "allocationInfo": {
+        "role": "*"
+      }
+    }, {
+      "name": "cpus",
+      "type": "SCALAR",
+      "scalar": {
+        "value": 0.1
+      },
+      "role": "*",
+      "allocationInfo": {
+        "role": "*"
+      }
+    },{
       "name": "mem",
       "type": "SCALAR",
       "scalar": {

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
@@ -96,7 +96,7 @@ class MesosClientTests
     stats.size shouldBe 3
     stats.keys shouldBe Set("192.168.99.100", "192.168.99.101", "192.168.99.102")
     stats.foreach(_ match {
-      case (host, AgentStats(mem, cpus, ports, _)) =>
+      case (host, AgentStats(mem, cpus, ports, _, _)) =>
         if (host == "192.168.99.100") {
           cpus shouldBe 0.9
           ports shouldBe 199

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
@@ -96,7 +96,7 @@ class MesosClientTests
     stats.size shouldBe 3
     stats.keys shouldBe Set("192.168.99.100", "192.168.99.101", "192.168.99.102")
     stats.foreach(_ match {
-      case (host, AgentStats(mem, cpus, ports, _, _)) =>
+      case (host, AgentStats(mem, cpus, ports, _)) =>
         if (host == "192.168.99.100") {
           cpus shouldBe 0.9
           ports shouldBe 199

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
@@ -93,9 +93,15 @@ class MesosClientTests
     MesosClient.agentOfferHistory.size shouldBe 3
     MesosClient.agentOfferHistory.keys shouldBe Set("192.168.99.100", "192.168.99.101", "192.168.99.102")
     MesosClient.agentOfferHistory.foreach(_ match {
-      case (_, AgentStats(mem, cpus, _)) =>
+      case (host, AgentStats(mem, cpus, ports, _)) =>
         mem shouldBe 2902.0
-        cpus shouldBe 0.9
+        if (host == "192.168.99.101") {
+          cpus shouldBe 1.0
+          ports shouldBe 202
+        } else {
+          cpus shouldBe 0.9
+          ports shouldBe 199
+        }
     })
 
     //wait for post accept


### PR DESCRIPTION
prune agentstats that are > TTL age
added pureconfig to simplify tysafeconfig -> case class adapting