### PR TITLE
Update to newer versions of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     //for recordIO
     compile "com.lightbend.akka:akka-stream-alpakka-simple-codecs_${scalaVersion}:0.9"
     //for JSON printing of protobuf
-    compile "com.google.protobuf:protobuf-java-util:3.3.1"
+    compile "com.google.protobuf:protobuf-java-util:3.6.1"
 
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'
     testCompile "com.typesafe.akka:akka-testkit_${scalaVersion}:${akkaVersion}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       ZOO_PORT: 2188
 
   master:
-    image: mesosphere/mesos-master:${MESOS_VERSION-1.2.1}
+    image: mesosphere/mesos-master:${MESOS_VERSION-1.2.3}
     entrypoint:
       - sh
       - -c
@@ -21,7 +21,7 @@ services:
       - zk
 
   slave:
-    image: mesosphere/mesos-slave:${MESOS_VERSION-1.2.1}
+    image: mesosphere/mesos-slave:${MESOS_VERSION-1.2.3}
     privileged: true
 # See:  https://issues.apache.org/jira/browse/MESOS-3793
     # entrypoint:


### PR DESCRIPTION
Protobuf and Mesos 1.2.1 are a bit out of date and container CVEs we'd like to avoid. Just bumped forward versions a bit.