### PR TITLE
added CapacityError 

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -2,4 +2,5 @@
 mesos-actor {
   agent-stats-ttl = 1 minutes //minimum time that agent stats remain valid without an update; incrase time in case offer cycle is slow; decrease time ignore offer data that may be stale
   agent-stats-pruning-period = 5 seconds //time period between pruning of expired agent stats
+  //fail-pending-offer-cycles = 2 //fail tasks that are not matched within this number of offer cycles
 }

--- a/src/test/resources/emptyoffer.json
+++ b/src/test/resources/emptyoffer.json
@@ -1,0 +1,83 @@
+{
+  "offers": [{
+    "id": {
+      "value": "7168e411-c3e4-4e29-b292-9b12eda4aaca-O58"
+    },
+    "frameworkId": {
+      "value": "sample-11fdf320-311f-42b0-a284-dbc38bb8d191"
+    },
+    "agentId": {
+      "value": "db6b062d-84e3-4a2e-a8c5-98ffa944a304-S0"
+    },
+    "hostname": "192.168.99.100",
+    "resources": [{
+      "name": "ports",
+      "type": "RANGES",
+      "ranges": {
+        "range": [{
+          "begin": "11001",
+          "end": "11199"
+        }]
+      },
+      "role": "*",
+      "allocationInfo": {
+        "role": "*"
+      }
+    }, {
+      "name": "cpus",
+      "type": "SCALAR",
+      "scalar": {
+        "value": 0.0
+      },
+      "role": "*",
+      "allocationInfo": {
+        "role": "*"
+      }
+    }, {
+      "name": "mem",
+      "type": "SCALAR",
+      "scalar": {
+        "value": 0.0
+      },
+      "role": "*",
+      "allocationInfo": {
+        "role": "*"
+      }
+    }, {
+      "name": "disk",
+      "type": "SCALAR",
+      "scalar": {
+        "value": 0.0
+      },
+      "role": "*",
+      "allocationInfo": {
+        "role": "*"
+      }
+    }],
+    "attributes": [{
+      "name": "att1",
+      "type": "TEXT",
+      "text": {
+        "value": "att1valueslave1"
+      }
+    }, {
+      "name": "att2",
+      "type": "TEXT",
+      "text": {
+        "value": "att2valueslave1"
+      }
+    }],
+    "url": {
+      "scheme": "http",
+      "address": {
+        "hostname": "192.168.99.100",
+        "ip": "192.168.99.100",
+        "port": 5051
+      },
+      "path": "/slave(1)"
+    },
+    "allocationInfo": {
+      "role": "*"
+    }
+  }]
+}

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosTaskMatcherTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosTaskMatcherTests.scala
@@ -36,7 +36,7 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     val offers = ProtobufUtil.getOffers("/offer1.json")
 
     val tasks = List[TaskDef](TaskDef("taskId", "taskName", "dockerImage:someTag", 0.1, 256, List(8080)))
-    val taskMap =
+    val (taskMap, _) =
       new DefaultTaskMatcher().matchTasksToOffers("*", tasks, offers.getOffersList.asScala, new DefaultTaskBuilder())
 
     taskMap.size shouldBe 1
@@ -46,7 +46,7 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     val offers = ProtobufUtil.getOffers("/partialoffer.json")
 
     val tasks = List[TaskDef](TaskDef("taskId", "taskName", "dockerImage:someTag", 0.1, 256, List(8080)))
-    val taskMap =
+    val (taskMap, _) =
       new DefaultTaskMatcher()
         .matchTasksToOffers("whisk", tasks, offers.getOffersList.asScala, new DefaultTaskBuilder())
 
@@ -57,7 +57,7 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     val offers = ProtobufUtil.getOffers("/badoffer.json")
 
     val tasks = List[TaskDef](TaskDef("taskId", "taskName", "dockerImage:someTag", 0.1, 256, List(8080)))
-    val taskMap =
+    val (taskMap, _) =
       new DefaultTaskMatcher(badOffer)
         .matchTasksToOffers("*", tasks, offers.getOffersList.asScala, new DefaultTaskBuilder())
 
@@ -70,7 +70,7 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     val offers = ProtobufUtil.getOffers("/offer-noports.json")
 
     val tasks = List[TaskDef](TaskDef("taskId", "taskName", "dockerImage:someTag", 0.1, 256, List(8080)))
-    val taskMap =
+    val (taskMap, _) =
       new DefaultTaskMatcher().matchTasksToOffers("*", tasks, offers.getOffersList.asScala, new DefaultTaskBuilder())
 
     taskMap.size shouldBe 0
@@ -119,7 +119,7 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
         256,
         List(8080),
         constraints = Set(Constraint("att2", LIKE, "(?!att1value).*")))) //test negative lookahead to match same as UNLIKE
-    val taskMap =
+    val (taskMap, _) =
       new DefaultTaskMatcher().matchTasksToOffers("*", tasks, offers.getOffersList.asScala, new DefaultTaskBuilder())
     taskMap.values.flatten.map(_._1.getTaskId.getValue) shouldBe List("taskId2", "taskId3", "taskId4", "taskId5")
 
@@ -130,12 +130,18 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     val tasks = List[TaskDef](
       TaskDef("taskId", "taskName", "dockerImage:someTag", 0.5, 256, List(8080)),
       TaskDef("taskId2", "taskName2", "dockerImage:someTag2", 0.5, 256, List(8080)))
-    val taskMap =
+    val (taskMap, remaining) =
       new DefaultTaskMatcher().matchTasksToOffers("*", tasks, offers.getOffersList.asScala, new DefaultTaskBuilder())
 
     taskMap.size shouldBe 2
     taskMap.keys.map(_.getValue) shouldBe Set(
       "7168e411-c3e4-4e29-b292-9b12eda4aaca-O58",
       "7168e411-c3e4-4e29-b292-9b12eda4aaca-O60")
+
+    remaining.map(r => r._1.getValue -> r._2) shouldBe Map(
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O58" -> (2656.0.toFloat, 0.3.toFloat, 198),
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O60" -> (2646.0.toFloat, 0.4.toFloat, 198),
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O59" -> (2902.0.toFloat, 1.0.toFloat, 199))
+
   }
 }


### PR DESCRIPTION
To be used for failing task launch promises (Failure message to ask sender) after some number of unmatched offer cycles. This allows preventions of timeout waits on task launch when there is an obvious resource deficit.