### PR TITLE
task packing when holding offers

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,4 +6,5 @@ mesos-actor {
   hold-offers = false //when true, offers for this role will be held instead of declined immediately when no pending tasks can use the offer(s)
   hold-offers-ttl = 10 seconds //minimum time that offers will be held after which they will be declined
   hold-offers-pruning-period = 5 seconds //time period between pruning of expired held offers
+  wait-for-preferred-agent = true //skip offer cycles if there are no offers from the preferred agent (agent affinity is based on least available memory, per DefaultTaskMatcher)
 }

--- a/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClient.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClient.scala
@@ -604,11 +604,10 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
           val usableUnusedOffers =
             agentOfferMap.filter(
               a =>
-                //TODO: consider current offerset to determine least used! (during restart)
                 unusedOfferIds.contains(a._1.getId) && !matchedTasks.keySet
                   .contains(a._1.getId))
           //we may hold offers that were not accepted, but if we are waiting for a specific agent they wouldn't be used anyways...
-          if (usableUnusedOffers.nonEmpty) { //don't let held offers trigger offer cycles if we are waiting for a specific agent offer
+          if (usableUnusedOffers.nonEmpty) {
             logger.info(
               s"holding ${usableUnusedOffers.size} unused offers: ${usableUnusedOffers.map(_._1.getHostname)}")
             //save the usable ones

--- a/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClient.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClient.scala
@@ -183,6 +183,8 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
   var heartbeatMonitor: Option[Cancellable] = None
   var heartbeatFailures: Int = 0
   var heldOffers: Map[OfferID, HeldOffer] = Map.empty
+  var waitForAgent
+    : Option[String] = None //when set, offers will be skipped until we see an offer from this specific agent, OR some offers are reaching their max offer cycles
   var pendingHeldOfferMatch: Boolean = false
   var stopping: Boolean = false
 
@@ -260,8 +262,7 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
       val taskPromise = Promise[Running]()
       tasks.update(task.taskId, SubmitPending(task, taskPromise))
       //if we are allowed to hold offers, signal use of those immediately, but only if not already signaled
-      val now = Instant.now()
-      if (config.holdOffers && heldOffers.nonEmpty && taskFitsHeldOffers(task) && !pendingHeldOfferMatch) {
+      if (config.holdOffers && taskFitsHeldOffers(task) && !pendingHeldOfferMatch) {
         pendingHeldOfferMatch = true
         //don't do offer matching here, or send the held offers (which may go away), rather trigger a separate offer cycle
         //that only uses the held offers
@@ -349,11 +350,12 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
         sender() ! Future.successful({})
       }
     case MatchHeldOffers =>
-      pendingHeldOfferMatch = false //reset flag to allow signaling again
-      if (heldOffers.nonEmpty) {
+      pendingHeldOfferMatch = false //reset flag to allow signaling again (would be better as FSM)
+      //use held offers IFF we have held offers AND either a) matching waitForAgent or b) empty waitForAgent
+      if (heldOffers.nonEmpty && waitForAgent.forall(h => heldOffers.values.map(_.offer.getHostname).exists(_ == h))) {
         log.info(s"attempting to use ${heldOffers.size} held offers")
-        val heldOffersMessage = Event.Offers.newBuilder().addAllOffers(heldOffers.values.map(_.offer).asJava).build()
-        handleOffers(heldOffersMessage)
+        //send empty offer list (held offers will be merged within handleOffers)
+        handleOffers(Event.Offers.getDefaultInstance)
       }
     case msg => log.warning(s"unknown msg: ${msg}")
   }
@@ -506,9 +508,20 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
     super.postRestart(reason)
   }
 
-  def handleOffers(event: Event.Offers) = {
-
-    log.debug(s"received ${event.getOffersList.size} offers: ${toCompactJsonString(event);}")
+  def handleOffers(newOffers: Event.Offers) = {
+    //merge held offers into any offers just received
+    val event =
+      if (heldOffers.nonEmpty) {
+        log.info(s"including ${heldOffers.size} held offers ")
+        val heldOffersEvent = Event.Offers.newBuilder().addAllOffers(heldOffers.map(_._2.offer).asJava).build()
+        Event.Offers
+          .newBuilder()
+          .addAllOffers(newOffers.getOffersList)
+          .addAllOffers(heldOffersEvent.getOffersList)
+          .build()
+      } else {
+        newOffers
+      }
 
     val agentOfferMap = event.getOffersList.asScala
       .map(o => o -> o.getResourcesList.asScala.filter(_.getRole == role).groupBy(_.getName)) //map hostname to resource map including only resources allocated to this role
@@ -527,11 +540,49 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
 
       log.debug(s"agent offer stats: {}", agentOfferHistory)
 
-      val (matchedTasks, remaining) =
+      //if new offers include agent that we are waiting for, clear the wait state
+      waitForAgent.foreach { w =>
+        if (event.getOffersList.asScala.exists(_.getHostname == w)) {
+          log.info(s"resetting waitForAgent since we received an offer on ${w}")
+          waitForAgent = None
+        } else {
+          //if any tasks are close to expiring, clear the wait state
+          val countAtLimit = countPendingAtOfferCycleLimit()
+          if (countAtLimit > 0) {
+            log.info(s"resetting waitForAgent since ${countAtLimit} pending tasks are at offer cycle limit")
+            waitForAgent = None
+          }
+        }
+      }
+
+      val (matchedTasks, remaining) = if (pending.nonEmpty && waitForAgent.isEmpty) {
         taskMatcher.matchTasksToOffers(role, pending, event.getOffersList.asScala.toList, taskBuilder)
+      } else {
+        waitForAgent.foreach(w => log.info(s"skipping offers due to waitForAgent ${w}"))
+        //TODO: do not return empty map, it may cause errors on maxBy in caller!
+        (Map.empty[OfferID, Seq[(TaskInfo, Seq[Int])]], Map.empty[OfferID, (Float, Float, Int)])
+      }
+
+//      //if we matched to a single offer (single host), skip use of held offers till next offer cycle
+//      if (matchedTasks.size == 1) { //we assume that the` precise match is not consuming all resources
+//        waitForAgent = agentOfferMap.keySet.find(_.getId == matchedTasks.head._1).map(_.getHostname)
+//        log.info(s"setting waitForAgent to ${waitForAgent}")
+//      } else
+//
+      if (matchedTasks.nonEmpty) {
+        val smallestRemainingOfferId = remaining.toSeq.minBy(_._2._1)._1
+        waitForAgent = agentOfferMap.keySet.find(_.getId == smallestRemainingOfferId).map(_.getHostname)
+        log.info(s"setting waitForAgent to ${waitForAgent}")
+
+      } else {
+        //leave waitForAgent unchanged
+      }
 
       val matchedCount = matchedTasks.foldLeft(0)(_ + _._2.size)
-      log.info(s"matched ${matchedCount} tasks to ${matchedTasks.size} offers out of ${pending.size} pending tasks")
+      val matchedOrNone = if (matchedCount > 0) "MATCHED" else "NOMATCHES"
+      val pendingOrNone = if (pending.size > 0) "PENDING" else "NOPENDINGS"
+      log.info(
+        s"${matchedOrNone} ${pendingOrNone} matched ${matchedCount} tasks to ${matchedTasks.size} offers out of ${pending.size} pending tasks")
 
       //debugging logs
       pending.foreach(reqs => {
@@ -549,19 +600,26 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
       //Decline the offers not selected. Sometimes these just stay dangling in mesos outstanding offers
       val unusedOfferIds =
         asScalaBuffer(event.getOffersList).map(offer => offer.getId).filter(!matchedTasks.contains(_))
+      //do not refill heldOffers if we are stopping
+      heldOffers = Map.empty //heldOffers -- matchedOffers //remove matched offers from heldOffers
       if (config.holdOffers && !stopping) { //handle held offers
-        //remove matched offers
-        val matchedOffers = matchedTasks.keySet
-        heldOffers = heldOffers -- matchedOffers //remove matched offers from heldOffers
+//        //remove matched offers
+//        val matchedOffers = matchedTasks.keySet
 
         //add remaining unused offers
-        if (unusedOfferIds.nonEmpty) {
+        if (unusedOfferIds.nonEmpty && config.holdOffers) {
           val now = Instant.now()
-          //find the usable ones
+          //find the usable ones but if this offer host is the least used host, do not hold it...
           val usableUnusedOffers =
-            agentOfferMap.filter(a => unusedOfferIds.contains(a._1.getId) && !matchedOffers.contains(a._1.getId))
-          if (usableUnusedOffers.size > 0) {
-            logger.info(s"holding ${usableUnusedOffers.size} unused offers")
+            agentOfferMap.filter(
+              a =>
+                //TODO: consider current offerset to determine least used! (during restart)
+                unusedOfferIds.contains(a._1.getId) && !matchedTasks.keySet
+                  .contains(a._1.getId))
+          //we may hold offers that were not accepted, but if we are waiting for a specific agent they wouldn't be used anyways...
+          if (usableUnusedOffers.nonEmpty) { //don't let held offers trigger offer cycles if we are waiting for a specific agent offer
+            logger.info(
+              s"holding ${usableUnusedOffers.size} unused offers: ${usableUnusedOffers.map(_._1.getHostname)}")
             //save the usable ones
             usableUnusedOffers.foreach(
               o =>
@@ -573,7 +631,7 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
           //remove the usable from unused
           val unusableUnusedOfferIds = unusedOfferIds -- heldOffers.keys
           //decline unused - usableUnused
-          if (unusableUnusedOfferIds.size > 0) {
+          if (unusableUnusedOfferIds.nonEmpty) {
             logger.info(s"declining ${unusableUnusedOfferIds.size} unused or unusable offers")
             declineOffers(unusableUnusedOfferIds)
           }
@@ -824,6 +882,8 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
         if (heldOffers.keySet.contains(rescinded)) {
           logger.info(s"removing held offer id ${rescinded.getValue} on rescind")
           heldOffers = heldOffers - rescinded
+        } else {
+          logger.warning(s"unknown offer rescinded ${rescinded.getValue}")
         }
       case Event.Type.FAILURE => logger.warning(s"received failure message ${event.getFailure}")
       case Event.Type.ERROR   => logger.error(s"received error ${event.getError}")
@@ -833,6 +893,23 @@ trait MesosClientActor extends Actor with ActorLogging with MesosClientConnectio
   }
   def toCompactJsonString(message: com.google.protobuf.Message) =
     JsonFormat.printer.omittingInsignificantWhitespace.print(message)
+
+  //return true if this host has largest amount of available resources
+  private def isLeastUsed(hostname: String): Boolean = {
+    val leastUsed = agentOfferHistory.size > 1 && agentOfferHistory.toList.minBy(-_._2.mem)._1 == hostname
+    if (leastUsed) log.info(s"offer is on least used agent ${hostname}")
+    leastUsed
+  }
+
+  private def countPendingAtOfferCycleLimit() = {
+    config.failPendingOfferCycles
+      .map { maxOfferCycles =>
+        tasks
+          .collect { case (_, s: SubmitPending) => s }
+          .count(_.offerCycles > math.max(1, maxOfferCycles - 1))
+      }
+      .getOrElse(0)
+  }
 }
 
 class MesosClient(val id: () => String,

--- a/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClientHttpConnection.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClientHttpConnection.scala
@@ -81,7 +81,8 @@ trait MesosClientHttpConnection extends MesosClientConnection {
     queue.offer(req, responsePromise)
     responsePromise.future
   }
-
+  private val hostname
+    : String = sys.env.get("LIBPROCESS_IP").getOrElse(java.net.InetAddress.getLocalHost.getHostName) //shows in mesos ui->Frameworks->Host
   def subscribe(frameworkID: FrameworkID,
                 frameworkName: String,
                 failoverTimeoutSecond: Double): Future[SubscribeComplete] = {
@@ -101,6 +102,7 @@ trait MesosClientHttpConnection extends MesosClientConnection {
               .setId(frameworkID)
               .setUser(Optional.ofNullable(System.getenv("user")).orElse("root")) // https://issues.apache.org/jira/browse/MESOS-3747
               .setName(frameworkName)
+              .setHostname(hostname)
               .setFailoverTimeout(failoverTimeoutSeconds.toSeconds)
               .setRole(role)
               .build)

--- a/src/main/scala/com/adobe/api/platform/runtime/mesos/TaskMatcher.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/mesos/TaskMatcher.scala
@@ -37,10 +37,16 @@ class DefaultTaskMatcher(isValid: Offer => Boolean = _ => true) extends TaskMatc
 
     var tasksInNeed: ListBuffer[TaskDef] = t.to[ListBuffer]
     var result = Map[OfferID, Seq[(TaskInfo, Seq[Int])]]()
-    val sortedOffers = o.toSeq.sortBy(
-      _.getResourcesList.asScala
-        .find(_.getName == "mem")
-        .map(_.getScalar.getValue))
+
+    val sortedOffers = o
+      .filter(o => o.getResourcesList.asScala.exists(_.getRole == role)) //filter out offers that don't have at least one resource with this role
+      .toSeq //convert to sequence for sorting
+      .sortBy(
+        _.getResourcesList.asScala
+          .filter(_.getRole == role)
+          .find(_.getName == "mem")
+          .map(_.getScalar.getValue))
+    logger.info(s"sorted offers ${sortedOffers.map(_.getHostname)}")
     var remaining: Map[OfferID, (Float, Float, Int)] = Map.empty
     sortedOffers.foreach(offer => {
       try {

--- a/src/test/resources/emptyoffer.json
+++ b/src/test/resources/emptyoffer.json
@@ -9,7 +9,7 @@
     "agentId": {
       "value": "db6b062d-84e3-4a2e-a8c5-98ffa944a304-S0"
     },
-    "hostname": "192.168.99.100",
+    "hostname": "192.168.99.101",
     "resources": [{
       "name": "ports",
       "type": "RANGES",

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
@@ -650,7 +650,7 @@ class MesosClientTests
     override val tasks: TaskStore = new LocalTaskStore
     override val refuseSeconds: Double = 1.0
     override val heartbeatMaxFailures: Int = 2
-    override val config = MesosActorConfig(5.seconds, 30.seconds, Some(3), true, 5.seconds, 30.seconds)
+    override val config = MesosActorConfig(5.seconds, 30.seconds, Some(3), true, 5.seconds, 30.seconds, true)
 
     override def exec(call: Call): Future[HttpResponse] = {
       log.info(s"sending ${call.getType}")

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosClientTests.scala
@@ -230,7 +230,8 @@ class MesosClientTests
         List(8080),
         healthCheckParams = Some(HealthCheckConfig(healthCheckPortIndex = 0)),
         commandDef = Some(CommandDef(environment = Map("__OW_API_HOST" -> "192.168.99.100")))))
-    //receive 3 empty offers (default max offers is 2, then capacity failure)
+    //receive 4 empty offers (configured max offers is 3, then capacity failure)
+    mesosClient ! ProtobufUtil.getOffers("/emptyoffer.json")
     mesosClient ! ProtobufUtil.getOffers("/emptyoffer.json")
     mesosClient ! ProtobufUtil.getOffers("/emptyoffer.json")
     mesosClient ! ProtobufUtil.getOffers("/emptyoffer.json")
@@ -550,10 +551,7 @@ class MesosClientTests
       .newBuilder()
       .setValue("db6b062d-84e3-4a2e-a8c5-98ffa944a304-S1")
       .build()
-    val agentId3 = AgentID
-      .newBuilder()
-      .setValue("db6b062d-84e3-4a2e-a8c5-98ffa944a304-S2")
-      .build()
+
     //receive the task details after successful launch
     system.log.info("sending UPDATE")
 
@@ -616,7 +614,7 @@ class MesosClientTests
         "taskId2",
         "fake-docker-image",
         0.1,
-        2500,
+        2500, //matches 102 agent -> 412mb remain
         List(8080),
         healthCheckParams = Some(HealthCheckConfig(healthCheckPortIndex = 0)),
         commandDef = Some(CommandDef(environment = Map("__OW_API_HOST" -> "192.168.99.100")))))
@@ -626,11 +624,13 @@ class MesosClientTests
         "taskId3",
         "fake-docker-image",
         0.1,
-        256,
+        2000, //matches 100 agent -> 912mb remain
         List(8080),
         healthCheckParams = Some(HealthCheckConfig(healthCheckPortIndex = 0)),
         commandDef = Some(CommandDef(environment = Map("__OW_API_HOST" -> "192.168.99.100")))))
 
+    //sending an empty offer will trigger reuse of held offers also, and since even though the held offer is least used node, it will get used after 3 offer cycles regardless
+    mesosClient ! ProtobufUtil.getOffers("/emptyoffer.json")
     expectMsg("ACCEPT_SENT")
     expectMsg("ACCEPT_SENT")
   }
@@ -650,7 +650,7 @@ class MesosClientTests
     override val tasks: TaskStore = new LocalTaskStore
     override val refuseSeconds: Double = 1.0
     override val heartbeatMaxFailures: Int = 2
-    override val config = MesosActorConfig(5.seconds, 30.seconds, Some(2), true, 5.seconds, 30.seconds)
+    override val config = MesosActorConfig(5.seconds, 30.seconds, Some(3), true, 5.seconds, 30.seconds)
 
     override def exec(call: Call): Future[HttpResponse] = {
       log.info(s"sending ${call.getType}")


### PR DESCRIPTION
when holding offers, wait for another offer from last-matched agent before continuing, so that tasks will gravitate towards most used agents