### PR TITLE
send events as messages 

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClientHttpConnection.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/mesos/MesosClientHttpConnection.scala
@@ -138,7 +138,7 @@ trait MesosClientHttpConnection extends MesosClientConnection {
       })
       .foreach(eventSource => {
         eventSource.runForeach(event => {
-          handleEvent(event)
+          self ! event //important! send events for serial processing
         })
       })
 

--- a/src/test/resources/offer-multiple.json
+++ b/src/test/resources/offer-multiple.json
@@ -241,5 +241,86 @@
       "allocationInfo": {
         "role": "*"
       }
+    },
+    {
+      "id": {
+        "value": "7168e411-c3e4-4e29-b292-9b12eda4aaca-O61"
+      },
+      "frameworkId": {
+        "value": "sample-11fdf320-311f-42b0-a284-dbc38bb8d191"
+      },
+      "agentId": {
+        "value": "db6b062d-84e3-4a2e-a8c5-98ffa944a304-S2"
+      },
+      "hostname": "192.168.99.102",
+      "resources": [{
+        "name": "ports",
+        "type": "RANGES",
+        "ranges": {
+          "range": [{
+            "begin": "12001",
+            "end": "12199"
+          }]
+        },
+        "role": "*",
+        "allocationInfo": {
+          "role": "*"
+        }
+      }, {
+        "name": "cpus",
+        "type": "SCALAR",
+        "scalar": {
+          "value": 0.9
+        },
+        "role": "*",
+        "allocationInfo": {
+          "role": "*"
+        }
+      }, {
+        "name": "mem",
+        "type": "SCALAR",
+        "scalar": {
+          "value": 2902.0
+        },
+        "role": "*",
+        "allocationInfo": {
+          "role": "*"
+        }
+      }, {
+        "name": "disk",
+        "type": "SCALAR",
+        "scalar": {
+          "value": 13185.0
+        },
+        "role": "*",
+        "allocationInfo": {
+          "role": "*"
+        }
+      }],
+      "attributes": [{
+        "name": "att1",
+        "type": "TEXT",
+        "text": {
+          "value": "att1valueslave2"
+        }
+      }, {
+        "name": "att2",
+        "type": "TEXT",
+        "text": {
+          "value": "att2valueslave2"
+        }
+      }],
+      "url": {
+        "scheme": "http",
+        "address": {
+          "hostname": "192.168.99.100",
+          "ip": "192.168.99.100",
+          "port": 5051
+        },
+        "path": "/slave(2)"
+      },
+      "allocationInfo": {
+        "role": "*"
+      }
     }]
 }

--- a/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosTaskMatcherTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/mesos/mesos/MesosTaskMatcherTests.scala
@@ -164,7 +164,8 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     remaining.map(r => r._1.getValue -> r._2) shouldBe Map(
       "7168e411-c3e4-4e29-b292-9b12eda4aaca-O58" -> (2912.0.toFloat, 0.8.toFloat, 199),
       "7168e411-c3e4-4e29-b292-9b12eda4aaca-O59" -> (2645.0.toFloat, 0.5.toFloat, 198),
-      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O60" -> (2646.0.toFloat, 0.3.toFloat, 198))
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O60" -> (2646.0.toFloat, 0.3.toFloat, 198),
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O61" -> (2902.0.toFloat, 0.9.toFloat, 199))
 
   }
 
@@ -193,7 +194,8 @@ class MesosTaskMatcherTests extends FlatSpec with Matchers {
     remaining.map(r => r._1.getValue -> r._2) shouldBe Map(
       "7168e411-c3e4-4e29-b292-9b12eda4aaca-O58" -> (2912.0.toFloat, 0.8.toFloat, 199),
       "7168e411-c3e4-4e29-b292-9b12eda4aaca-O59" -> (2645.0.toFloat, 0.5.toFloat, 198),
-      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O60" -> (2646.0.toFloat, 0.3.toFloat, 198))
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O60" -> (2646.0.toFloat, 0.3.toFloat, 198),
+      "7168e411-c3e4-4e29-b292-9b12eda4aaca-O61" -> (2902.0.toFloat, 0.9.toFloat, 199))
 
   }
 }


### PR DESCRIPTION
To avoid concurrent event processing, e.g. where held offers that were rescinded are used to launch tasks, if the events were handled concurrently
Added test for rescind;